### PR TITLE
 Make TOP_K configurable and clean up imports

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -14,7 +14,7 @@ class Config(BaseModel):
     GROQ_API_KEY: str = Field(default_factory=lambda: os.getenv("GROQ_API_KEY", ""))
     GEN_MODEL_ID: str = "meta-llama/llama-4-scout-17b-16e-instruct"
     GEN_TEMPERATURE: float = 0.05
-    TOP_K: int = 3
+    TOP_K: int = Field(default_factory=lambda: int(os.getenv("TOP_K", "5")))
 
     class Config:
         arbitrary_types_allowed = True

--- a/src/nodes/check_hallucination.py
+++ b/src/nodes/check_hallucination.py
@@ -1,0 +1,42 @@
+from langchain_core.language_models import BaseChatModel
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+from .graph_state import GraphState
+
+
+def check_hallucination(llm: BaseChatModel):
+    def _check(state: GraphState) -> GraphState:
+        question = state["question"]
+        documents = state["documents"]
+        generation = state["generation"]
+
+        hallucination_prompt = ChatPromptTemplate.from_template(
+            """You are a grader assessing whether an answer is grounded in / supported by a set of facts.
+
+            Set of facts:
+            {documents}
+
+            Answer: {generation}
+
+            Give a binary score 'yes' or 'no' to indicate whether the answer is grounded in the facts.
+            Provide only 'yes' or 'no' as output."""
+        )
+
+        chain = hallucination_prompt | llm | StrOutputParser()
+
+        context = "\n\n".join([doc.page_content for doc in documents])
+        score = chain.invoke({
+            "documents": context,
+            "generation": generation
+        })
+
+        is_grounded = "yes" in score.lower()
+        steps = [f"Hallucination check: {'passed' if is_grounded else 'failed'}"]
+
+        return {
+            **state,
+            "answer_grounded": is_grounded,
+            "steps": steps
+        }
+
+    return _check


### PR DESCRIPTION
  - Make TOP_K configurable via environment variable (default: 5, previously: 3)
  - Add proper type conversion for TOP_K to ensure integer type
  - Remove unused TYPE_CHECKING import from check_hallucination module
  - Add newline at end of check_hallucination.py for POSIX compliance